### PR TITLE
Embed a video from Vimeo on Screencasts#show

### DIFF
--- a/app/helpers/screencasts_helper.rb
+++ b/app/helpers/screencasts_helper.rb
@@ -1,2 +1,5 @@
 module ScreencastsHelper
+  def screencast_video(screencast)
+    tag.iframe src: "https://player.vimeo.com/video/#{screencast.video_id}", allow: "fullscreen", title: screencast.title
+  end
 end

--- a/app/views/screencasts/show.html.erb
+++ b/app/views/screencasts/show.html.erb
@@ -1,2 +1,3 @@
+<%= screencast_video(@screencast) %>
 <h1><%= @screencast.title %></h1>
 <p>Find me in app/views/screencasts/show.html.erb</p>

--- a/db/migrate/20240609214253_rename_video_url_to_video_id_on_screencasts.rb
+++ b/db/migrate/20240609214253_rename_video_url_to_video_id_on_screencasts.rb
@@ -1,0 +1,5 @@
+class RenameVideoUrlToVideoIdOnScreencasts < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :screencasts, :video_url, :video_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_09_152754) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_09_214253) do
   create_table "screencasts", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
     t.string "slug", null: false
-    t.string "video_url", null: false
+    t.string "video_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_screencasts_on_slug", unique: true

--- a/test/fixtures/screencasts.yml
+++ b/test/fixtures/screencasts.yml
@@ -2,4 +2,4 @@ kamal:
   title: Deploy your Rails application with Kamal
   description: Kamal is a deployment tool for Ruby on Rails applications based on Docker. It will allow you to deploy your Rails application with ease.
   slug: deployment-with-kamal
-  video_url: TODO
+  video_id: 903834205


### PR DESCRIPTION
In this commit, we add a screencast_video helper to embed a video from Vimeo on the Screencasts#show page.

We also rename the video_url column to video_id on the screencasts table.